### PR TITLE
Added docker-compose.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _build
 /images/Globals.pptx
 **/.DS_Store
 .vscode/settings.json
+docker-compose.yaml


### PR DESCRIPTION
For people using docker to build the docs locally. 
Example of docker-compose file:
![image](https://user-images.githubusercontent.com/85280808/166210156-dfa464e2-574a-44ef-8cf8-bee16beb30fa.png)
