### PR TITLE
Fixed description for primary_key attribute

### DIFF
--- a/configuration-sinks-sql.rst
+++ b/configuration-sinks-sql.rst
@@ -71,7 +71,7 @@ Properties
    * - ``primary_key``
      - List<String> or String
      - The value of this property can be a single string with the name of the column
-       that contains the ``primary key`` (PK) of the table, or a list of strings
+       that contains a ``unique key``, such as the primary key (PK) of the table, or a list of strings
        if it is a compound primary key. If the property is not set the component will
        attempt to use table metadata reflection to deduce the PK to use.
      -


### PR DESCRIPTION
Changed "Description" for sql sink attribute primary_key  to focus on a "unique key" instead of only the PK 

![Skjermdump fra 2022-05-04 12-23-46](https://user-images.githubusercontent.com/51788233/166664246-1ea2b952-60e5-4b49-9e21-dcb617caf99e.png)
