### PR TITLE
IS-12466: Connect tutorial

### DIFF
--- a/guide-create-first-synchronization.rst
+++ b/guide-create-first-synchronization.rst
@@ -9,6 +9,7 @@ Create your first synchronization
 
    Collect <tutorial-getting-started-collect>
    Enrich <tutorial-getting-started-enrich>
+   Connect <tutorial-getting-started-connect>
 
 In this guide we will show you how a general simplistic Sesam synchronization may take form. The goal is to give you an introductionary overview of the 5 standard phases (Collect, Enrich, Connect, Transform and Share) used in all Sesam synchronizations and to see their effects in `HubSpot <https://www.hubspot.com/>`_.
 

--- a/guide-create-first-synchronization.rst
+++ b/guide-create-first-synchronization.rst
@@ -71,15 +71,12 @@ In this guide we will show you how a general simplistic Sesam synchronization ma
             :text: Start this tutorial
             :classes: tutorial-start
 
-    .. dropdown:: **Connect data** (coming soon)
+    .. dropdown:: **Connect data**
+        :open:
         
-        ..
-            :badge:`Estimated time: 5 min,badge-light`
+        :badge:`Estimated time: 15 min,badge-light`
 
-        Coming soon
-
-        ..
-            This tutorial will show you how to connect the data your enriched.
+        This tutorial will show you how to connect the data your enriched.
 
             .. link-button:: tutorial-getting-started-connect
                 :type: ref

--- a/tutorial-getting-started-collect.rst
+++ b/tutorial-getting-started-collect.rst
@@ -151,7 +151,7 @@ The first inbound pipe we want to work on is the pipe that connects to our ``Hub
           "url": "companies?properties=about_us,address,city,country,description,domain,founded_year,is_public,linkedin_company_page,name,numberofemployees,state,timezone,website,zip&"
         }
       },
-      "add_namespaces": false
+      "namespaced_identifiers": false
     }
 
 
@@ -188,7 +188,7 @@ The last thing to do in this tutorial is to create the inbound pipe for Enhetsre
           ]
         }
       },
-      "add_namespaces": false
+      "namespaced_identifiers": false
     }
 
 When done you should have 10 entities in the output of each of the two inbound pipes.

--- a/tutorial-getting-started-connect.rst
+++ b/tutorial-getting-started-connect.rst
@@ -1,32 +1,84 @@
-:orphan:
-
 .. _tutorial_getting_started_connect:
 
 Connect data
 ============
 
-In this tutorial we will look closer into how to...
+.. In this phase we will find sameness from our two sources and merge them into one.
+
+In this phase we will see how the same companies from different sources can be merged for a more complete perspective of the prespective companies.
+We will also get a small taste of master data management (MDM) mechanisms in Sesam.
 
 .. admonition::  Objectives:
-   
-    After you complete this tutorial you would have learned the following:
 
-    #. Objective
-    #. Objective
-    #. Objective
+    After you complete this tutorial you will have learned the following:
 
+    #. How to merge entities from different sources
+    #. How to define global properties
 
 .. admonition:: Prerequisites
 
-  Before starting on this tutorial we suggest you...
-    - Completed `Collect data tutorial <tutorial-getting-started-collect>`_
-    - Completed `Enrich data tutorial <tutorial-getting-started-enrich>`_
-    - 
-    - 
-    
-  You should also acquire:
-    - 
-    - 
-    - 
-    - 
+  Before starting on this tutorial we suggest you complete the `Enrich data tutorial <tutorial-getting-started-enrich>`_ as we will use that data in this tutorial.
 
+Create global pipe
+******************
+To create a global pipe, follow the steps below. 
+
+#. Navigate to **Pipes**
+#. Click on **New pipe**
+#. Paste and save the configuration below
+#. Click **Start** to ensure your pipe runs 
+#. Click the **Output** tab to see the result
+
+.. code-block:: json
+  :linenos:
+  
+  {
+    "_id": "global-company",
+    "type": "pipe",
+    "source": {
+      "type": "merge",
+      "datasets": ["enhetsregisteret-company-enrich ec", "hubspot-company-enrich hc"],
+      "equality_sets": [
+        ["ec.orgnr", "hc.properties.about_us"]
+      ],
+      "identity": "first",
+      "version": 2
+    },
+    "transform": {
+      "type": "dtl",
+      "rules": {
+        "default": [
+          ["copy", "*"],
+          ["add", "name",
+            ["coalesce",
+              ["list", "_S.enhetsregisteret-company:navn", "_S.hubspot-company:properties.hubspot-company:name"]
+            ]
+          ],
+          ["add", "zipcode",
+            ["coalesce",
+              ["list", "_S.enhetsregisteret-company:forradrpostnr", "_S.hubspot-company:properties.hubspot-company:zip"]
+            ]
+          ]
+        ]
+      }
+    },
+    "metadata": {
+      "global": true
+    }
+  }
+
+``"identity": "first"`` tells Sesam to pick the ``_id`` from the first dataset source as ``_id`` for the merged entity.
+
+We use ``orgnr`` from Enhetsregisteret and ``about_us`` from HubSpot to find matching companies from the two systems.
+
+Notice how the matching companies from the two sources have been merged together.
+
+Also notice how ``$ids`` and ``rdf:type`` have data from both sources.
+
+The properties we added in the global pipe are listed in the ``global-company`` namespace.
+We use ``coalesce`` to determine the trust we have in each source, the first source begin the one we trust the most.
+
+These global properties will be used later in the transform phase.
+
+..
+    To learn more about connecting data in Sesam, see the Learn section Connect

--- a/tutorial-getting-started-connect.rst
+++ b/tutorial-getting-started-connect.rst
@@ -3,10 +3,9 @@
 Connect data
 ============
 
-.. In this phase we will find sameness from our two sources and merge them into one.
-
-In this phase we will see how the same companies from different sources can be merged for a more complete perspective of the prespective companies.
-We will also get a small taste of master data management (MDM) mechanisms in Sesam.
+In this phase we will demonstrate how to connect data across different sources.
+More specifically how the same companies from different sources can be merged to give us a more complete perspective of the respective companies.
+We will also get a small taste of master data management (MDM) mechanisms in Sesam by adding global properties.
 
 .. admonition::  Objectives:
 
@@ -33,7 +32,7 @@ To create a global pipe, follow the steps below.
   :linenos:
   
   {
-    "_id": "global-company",
+    "_id": "global-organization",
     "type": "pipe",
     "source": {
       "type": "merge",
@@ -49,14 +48,29 @@ To create a global pipe, follow the steps below.
       "rules": {
         "default": [
           ["copy", "*"],
+          ["add", "organization-number",
+            ["coalesce",
+              ["list", "_S.enhetsregisteret-company:orgnr", "_S.hubspot-company:properties.hubspot-company:about_us"]
+            ]
+          ],
           ["add", "name",
             ["coalesce",
               ["list", "_S.enhetsregisteret-company:navn", "_S.hubspot-company:properties.hubspot-company:name"]
             ]
           ],
+          ["add", "address",
+            ["coalesce",
+              ["list", "_S.enhetsregisteret-company:forretningsadr", "_S.hubspot-company:properties.hubspot-company:address"]
+            ]
+          ],
           ["add", "zipcode",
             ["coalesce",
               ["list", "_S.enhetsregisteret-company:forradrpostnr", "_S.hubspot-company:properties.hubspot-company:zip"]
+            ]
+          ],
+          ["add", "city",
+            ["coalesce",
+              ["list", "_S.enhetsregisteret-company:forradrpoststed", "_S.hubspot-company:properties.hubspot-company:city"]
             ]
           ]
         ]
@@ -67,16 +81,20 @@ To create a global pipe, follow the steps below.
     }
   }
 
-``"identity": "first"`` tells Sesam to pick the ``_id`` from the first dataset source as ``_id`` for the merged entity.
+Important to note here is that we fetch companies from *different sources* (Enhentsregisteret and HubSpot),
+and merge the company entities when ``orgnr`` from Enhetsregisteret matches ``about_us`` from HubSpot.
 
-We use ``orgnr`` from Enhetsregisteret and ``about_us`` from HubSpot to find matching companies from the two systems.
+Also notice how ``$ids`` and ``rdf:type`` have data from both sources, meaning we don't lose data.
+We aggregate and preserve from all sources.
 
-Notice how the matching companies from the two sources have been merged together.
+The properties we added are listed in the ``global-organization`` namespace.
+Properties in a global namespace are what we call *global properties*.
 
-Also notice how ``$ids`` and ``rdf:type`` have data from both sources.
+We use ``coalesce`` to determine the trust we have in each source, the first source being the one we trust most.
+This is one of the mechanisms Sesam provides for MDM.
 
-The properties we added in the global pipe are listed in the ``global-company`` namespace.
-We use ``coalesce`` to determine the trust we have in each source, the first source begin the one we trust the most.
+By adding the global properties we no longer need to worry about which source system has the most accurate data.
+From here on we can simply use the global properties instead when needed.
 
 These global properties will be used later in the transform phase.
 

--- a/tutorial-getting-started-connect.rst
+++ b/tutorial-getting-started-connect.rst
@@ -85,14 +85,12 @@ To create a global pipe, follow the steps below.
 Important to note here is that we fetch companies from *different sources* (Enhentsregisteret and HubSpot),
 and merge the company entities when ``orgnr`` from Enhetsregisteret matches ``about_us`` from HubSpot.
 
-Also notice how ``$ids`` and ``rdf:type`` have data from both sources, meaning we don't lose data.
-We aggregate and preserve from all sources.
+Also notice that data from all sources are preserved and aggregated in the result.
 
 The properties we added are listed in the ``global-organization`` namespace.
 Properties in a global namespace are what we call *global properties*.
 
-We use ``coalesce`` to determine the trust we have in each source, the first source being the one we trust most.
-This is one of the mechanisms Sesam provides for MDM.
+We use ``coalesce`` to determine the source trust order and is one of the mechanisms provided by Sesam for MDM.
 
 By adding the global properties we no longer need to worry about which source system has the most accurate data.
 From here on we can simply use the global properties instead when needed.

--- a/tutorial-getting-started-connect.rst
+++ b/tutorial-getting-started-connect.rst
@@ -5,6 +5,7 @@ Connect data
 
 In this phase we will demonstrate how to connect data across different sources.
 More specifically how the same companies from different sources can be merged to give us a more complete perspective of the respective companies.
+
 We will also get a small taste of master data management (MDM) mechanisms in Sesam by adding global properties.
 
 .. admonition::  Objectives:
@@ -18,8 +19,8 @@ We will also get a small taste of master data management (MDM) mechanisms in Ses
 
   Before starting on this tutorial we suggest you complete the `Enrich data tutorial <tutorial-getting-started-enrich>`_ as we will use that data in this tutorial.
 
-Create global pipe
-******************
+Create a global pipe
+********************
 To create a global pipe, follow the steps below. 
 
 #. Navigate to **Pipes**


### PR DESCRIPTION
- Fleshed out Connect tutorial
- In Collect config: changed from using "add_namespaces" to "namespaced_identifiers" to avoid potential duplication of namespaces on ``_id`` in case service.metadata already has "namespaced_indetifiers":true.