### PR TITLE
Added API GET parameter 'compressed' to '/datasets/{dataset_id}/entities'

### DIFF
--- a/swagger_public.yaml
+++ b/swagger_public.yaml
@@ -885,6 +885,14 @@ paths:
             If true then the response may include uncommitted entities. This is only relevant if the pipe that
             writes to the dataset have a circuit breaker enabled. Use this for debugging purposes only.
 
+        - name: compressed
+          in: query
+          required: false
+          type: boolean
+          default: false
+          description:
+            If true then the JSON response will be unformatted and presented in a single line.
+
         - name: subset
           in: query
           required: false


### PR DESCRIPTION
For some reason this paramter is not documented.
It is very helpful for downloading a pipe dataset to be used for tools like JQ.

The file size of the downloaded dataset will be drastically smaller with the compressed=true parameter.