### PR TITLE
IS-14987: Fix update url in Hubspot system config

### DIFF
--- a/hub/tutorial-getting-started-collect.rst
+++ b/hub/tutorial-getting-started-collect.rst
@@ -80,7 +80,7 @@ In the `Sesam portal <https://portal.sesam.io/>`_:
         "update": {
           "method": "PATCH",
           "payload-type": "json",
-          "url": "{{ properties.url }}/{{ properties.id }}?"
+          "url": "companies/{{ properties.id }}"
         }
       },
       "rate_limiting_delay": 60,
@@ -196,5 +196,3 @@ When done you should have 10 entities in the output of each of the two inbound p
   .. note::
 
       If you want to look closer into the details of the collect phase, look into the tutorials for collect.
-
-


### PR DESCRIPTION
`properties.url` is in the sink config and `properties.id` is in the sink entity. Seems there was some issue with this as I was getting an error saying that it couldn't render the url.

```
"lake.task.exceptions.DatasyncWriteException: Failed write attempt on sink 'sink:company-hubspot-share-update-endpoint' and too many write errors in the retry log (1).
The last error was: Could not render the operation url '{{ properties.url }}/{{ properties.id }}' for operation 'update'"
```

Ref [IS-14897](https://sesam.myjetbrains.com/youtrack/issue/IS-14987)