### PR TITLE
IS-14719: Documented the client_side_patching share template property

### DIFF
--- a/hub/documentation/service-configuration/pipes/configuration-sinks-dataset.rst
+++ b/hub/documentation/service-configuration/pipes/configuration-sinks-dataset.rst
@@ -30,14 +30,17 @@ Properties
 
    * - ``dataset``
      - String
-     - The id of the dataset to write entities into. Note: if it doesn't exist before
-       entities are written to the sink, it will be created on the fly.
+     - The id of the dataset to write entities into. You should normally not have to specify the dataset id 
+       as the default value is the pipe id, and there should be a very good reason for the dataset id to be 
+       different from the pipe id.
+
+       Note: if it doesn't exist before entities are written to the sink, it will be created on the fly.
 
        .. NOTE::
 
           The dataset id cannot contain forward slash characters (``/``) nor can it
           reference a ``system:`` dataset.
-     -
+     - The pipe id.
      - Yes
 
    * - ``set_initial_offset``

--- a/hub/documentation/service-configuration/pipes/configuration-transforms-template.rst
+++ b/hub/documentation/service-configuration/pipes/configuration-transforms-template.rst
@@ -370,6 +370,12 @@ Template properties
      -
      - No
 
+   * - ``client_side_patching``
+     - Boolean
+     - If set to ``true`` then the update payload will be built from the result of the lookup operation and then patched with the actual payload. The use-case for this when the REST operation does not support patching, but instead require a complete payload to be sent.
+     - ``false``
+     - No
+
 Special entity properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
And clarified the use of the "dataset_id" property on the dataset sink.