### PR TITLE
Update hubspot.rst

### DIFF
--- a/talk/systems/hubspot.rst
+++ b/talk/systems/hubspot.rst
@@ -15,7 +15,7 @@ Hubspot
     
     |
     
-    .. link-button:: https://hubspot.talk.market
+    .. link-button:: https://www.sesam.io/talk/hubspot
         :type: url
         :text: Try for free
         :classes: btn-primary btn-block

--- a/talk/systems/tripletex.rst
+++ b/talk/systems/tripletex.rst
@@ -16,7 +16,7 @@ Tripletex
     
     |
     
-    .. link-button:: https://tripletex.talk.market
+    .. link-button:: https://www.sesam.io/talk/tripletex
         :type: url
         :text: Try for free
         :classes: btn-primary btn-block


### PR DESCRIPTION
Links to HTTPS of URL redirects do not seem to work, fixed by correcting the URL