### PR TITLE
docs: warn against writing directly to datasets via API in production

### DIFF
--- a/hub/api.rst
+++ b/hub/api.rst
@@ -150,6 +150,11 @@ With curl:
 Get a list of all the datasets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+   Do not use the dataset API to write data in production. To push data into Sesam, use either an
+   :ref:`HTTP endpoint source <http_endpoint_source>` or the :ref:`JSON Push Protocol <json_push_protocol>`.
+
 With curl:
 
 ::

--- a/hub/json-push.rst
+++ b/hub/json-push.rst
@@ -1,3 +1,5 @@
+.. _json_push_protocol:
+
 ==================
 JSON Push Protocol
 ==================


### PR DESCRIPTION
The dataset API endpoint for posting entities is not intended for production use. Add a warning in api.rst directing users to use an HTTP endpoint source or the JSON Push Protocol instead.

Also adds a top-level RST label to json-push.rst so it can be referenced via :ref: consistently with the rest of the docs.